### PR TITLE
Fix plugin startup loop bug

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -593,6 +593,8 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 							gl.GL_DONT_CARE, 1, new int[]{0x20052}, 0, false);
 					}
 
+					lastFrameTime = System.currentTimeMillis();
+
 					initVao();
 					try
 					{


### PR DESCRIPTION
This fixes a bug introduced by 81a9886e3cc473e6ae3a2e2f57f869ae1d852ad0
where the plugin will continuously attempt to restart itself
indefinitely if the plugin had been turned off for longer than a minute.
This fixes the bug by also updating `lastFrameTime` in `startUp()`.